### PR TITLE
Revert "chore(deps-dev): Bump org.testng:testng from 7.5.1 to 7.10.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.10.1</version>
+            <version>7.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts tommyettinger/mvnrepository-client#27 .

Screw you, dependabot. That TestNG version is incompatible and you should know it.